### PR TITLE
Poprawienie tłumaczenia dla dodatku "System - Przejdź do"

### DIFF
--- a/administrator/language/pl-PL/plg_system_skipto.sys.ini
+++ b/administrator/language/pl-PL/plg_system_skipto.sys.ini
@@ -3,6 +3,6 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SYSTEM_SKIPTO="System - System - Przejdź do"
+PLG_SYSTEM_SKIPTO="System - Przejdź do"
 PLG_SYSTEM_SKIPTO_XML_DESCRIPTION="Tworzy menu rozwijane składające się z łączy do kluczowych obszarów strony internetowej. Ułatwia to użytkownikom klawiatury i czytników ekranu szybkie przejście do pożądanej lokalizacji."
 


### PR DESCRIPTION
Poprawienie tłumaczenia dla dodatku `System - Przejdź do`

### Streszczenie zmian

### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
![obraz](https://github.com/JoomlaPolska/jezyk-J4/assets/2000754/3e79e236-2878-4fa3-b2e1-57d0d2cd113c)

### Jak przetestować
Wystarczy znaleźć dodatek na liście dodatków.