### PR TITLE
[4.4] pagenavigation - dodaj brakującą etykietę

### DIFF
--- a/administrator/language/pl-PL/plg_content_pagenavigation.ini
+++ b/administrator/language/pl-PL/plg_content_pagenavigation.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTENT_PAGENAVIGATION="Artykuły - Nawigacja"
+PLG_PAGENAVIGATION_ARIA_LABEL="Między stronami"
 PLG_PAGENAVIGATION_FIELD_DISPLAY_LABEL="Tekst łącza"
 PLG_PAGENAVIGATION_FIELD_POSITION_LABEL="Pokaż/Ukryj kolumnę Stanowisko na liście kontaktów."
 PLG_PAGENAVIGATION_FIELD_RELATIVE_LABEL="Relatywnie do"


### PR DESCRIPTION
Dodano brakującą etykietę dla aria-label w pagenavigation
related #526