### PR TITLE
Brakująca fraza ostrzeżenia po włączeniu filtra jeżyków

### DIFF
--- a/administrator/language/pl-PL/plg_system_languagefilter.ini
+++ b/administrator/language/pl-PL/plg_system_languagefilter.ini
@@ -5,6 +5,7 @@
 
 PLG_SYSTEM_LANGUAGEFILTER="System - Filtr języków"
 PLG_SYSTEM_LANGUAGEFILTER_BROWSER_SETTINGS="Wybór przeglądarki"
+PLG_SYSTEM_LANGUAGEFILTER_ERROR_NO_CONTENT_LANGUAGE="Nie masz opublikowanego języka treści, ale włączony został dodatek filtra języków. Będzie skutkowało licznymi błędami!"
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_ALTERNATE_META_LABEL="Dodaj alternatywne znaczniki meta"
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_AUTOMATIC_CHANGE_LABEL="Automatyczna zmiana języka"
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_COOKIE_LABEL="Żywotność ciasteczek"


### PR DESCRIPTION
Pull Request do problemu #505  .

### Streszczenie zmian

### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
(np. zrób zrzut ekranu, podaj ścieżkę względną do ekranu

### Jak przetestować