### PR TITLE
Dodanie brakującej frazy z #529

### DIFF
--- a/administrator/language/pl-PL/plg_content_pagenavigation.ini
+++ b/administrator/language/pl-PL/plg_content_pagenavigation.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTENT_PAGENAVIGATION="Artykuły - Nawigacja"
+PLG_PAGENAVIGATION_ARIA_LABEL="Nawigacja strony"
 PLG_PAGENAVIGATION_FIELD_DISPLAY_LABEL="Tekst łącza"
 PLG_PAGENAVIGATION_FIELD_POSITION_LABEL="Pokaż/Ukryj kolumnę Stanowisko na liście kontaktów."
 PLG_PAGENAVIGATION_FIELD_RELATIVE_LABEL="Relatywnie do"
@@ -14,4 +15,3 @@ PLG_PAGENAVIGATION_FIELD_VALUE_NEXTPREV="Następny/Poprzedni (tekst statyczny)"
 PLG_PAGENAVIGATION_FIELD_VALUE_TEXT="Tekst"
 PLG_PAGENAVIGATION_FIELD_VALUE_TITLE="Tytuł artykułu"
 PLG_PAGENAVIGATION_XML_DESCRIPTION="Umożliwia dodanie do artykułu <em>Następny &amp; Poprzedni</em>."
-


### PR DESCRIPTION
Pull Request do problemu #529 .
Zmiany z https://github.com/joomla/joomla-cms/pull/43670/files#diff-a018f5d7d26e5212adb7f27a6f399f99216ed5ad6ec4306c39a84d8f403fdf54

### Streszczenie zmian

### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
(np. zrób zrzut ekranu, podaj ścieżkę względną do ekranu

### Jak przetestować