### PR TITLE
Brakująca fraza z #539

### DIFF
--- a/administrator/language/pl-PL/com_guidedtours.ini
+++ b/administrator/language/pl-PL/com_guidedtours.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_GUIDEDTOURS="Samouczki"
-COM_GUIDEDTOURS_AUTOSTART_DESC="Rozpocznij samouczek automatycznie kiedy użytkownik dotrze do kontekstu w jakim samouczek powinien być wyświetlony."
+COM_GUIDEDTOURS_AUTOSTART_DESC="Rozpocznij samouczek automatycznie, kiedy użytkownik dotrze do kontekstu, w jakim samouczek powinien być wyświetlony."
 COM_GUIDEDTOURS_CONFIGURATION="Samouczki: Opcje"
 COM_GUIDEDTOURS_DESCRIPTION="Opis"
 COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION="Opis (%s)"

--- a/administrator/language/pl-PL/com_guidedtours.ini
+++ b/administrator/language/pl-PL/com_guidedtours.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_GUIDEDTOURS="Samouczki"
+COM_GUIDEDTOURS_AUTOSTART_DESC="Rozpocznij samouczek automatycznie kiedy użytkownik dotrze do kontekstu w jakim samouczek powinien być wyświetlony."
 COM_GUIDEDTOURS_CONFIGURATION="Samouczki: Opcje"
 COM_GUIDEDTOURS_DESCRIPTION="Opis"
 COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION="Opis (%s)"


### PR DESCRIPTION
Pull Request do problemu #539 .
Zmiana z https://github.com/joomla/joomla-cms/pull/43690/files#diff-964987ca8071660af7bdf4dc91cc57eb1b4dd1e8739dafac281bc1219745c5c1R7

### Streszczenie zmian

### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
(np. zrób zrzut ekranu, podaj ścieżkę względną do ekranu

### Jak przetestować