### PR TITLE
Fixes 702

### DIFF
--- a/administrator/language/pl-PL/plg_system_schemaorg.ini
+++ b/administrator/language/pl-PL/plg_system_schemaorg.ini
@@ -8,9 +8,12 @@ PLG_SYSTEM_SCHEMAORG_BASETYPE_DESCRIPTION="Wybierz, czy Twoja strona reprezentuj
 PLG_SYSTEM_SCHEMAORG_BASETYPE_LABEL="Typ zadania"
 PLG_SYSTEM_SCHEMAORG_BASETYPE_OPTION_ORGANIZATION="Organizacja"
 PLG_SYSTEM_SCHEMAORG_BASETYPE_OPTION_PERSON="Osoba"
-PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION="Dane ustrukturyzowane są znormalizowanym formatem organizacji i reprezentowania informacji w sieci. Zapewnia on sposób na uporządkowany opis treści i znaczenia danych, ułatwienie znajomości i przetwarzania informacji przez wyszukiwarki i inne aplikacje. <a href=\"https://schema.org\" target=\"_blank\" rel=\"noopener noreferrer\">Więcej informacji na temat schema.org</a>."
+PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION="Dane strukturalne są znormalizowanym formatem organizacji i reprezentacji informacji w sieci. Zapewniają one sposób na opisanie treści i jej znaczenia w ustandaryzowany sposób, ułatwiając wyszukiwarkom i innym aplikacjom zrozumienie i przetwarzanie tych informacji. <a href=\"https://schema.org\" target=\"_blank\" rel=\"noopener noreferrer\">Więcej informacji na temat schema.org</a>."
+; The following two strings are deprecated and will be removed with 6.0
 PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION_NOT_CONFIGURATED="Aby użyć funkcji schema.org, musisz najpierw skonfigurować dodatek. Skontaktuj się z administratorem witryny, aby go skonfigurować."
 PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION_NOT_CONFIGURATED_ADMIN="Aby użyć funkcji schema.org, musisz najpierw skonfigurować dodatek. Wybierz <a href=\"index.php?option=com_plugins&amp;task=plugin.edit&amp;extension_id=%s\" target=\"_blank\">to łącze, aby otworzyć dodatek</a>, skonfigurować go i zapisać."
+PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION_NOT_CONFIGURED="Aby użyć funkcji schema.org, musisz najpierw skonfigurować dodatek. Skontaktuj się z administratorem witryny, aby go skonfigurować."
+PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION_NOT_CONFIGURED_ADMIN="Aby użyć funkcji schema.org, musisz najpierw skonfigurować dodatek. Wybierz <a href=\"index.php?option=com_plugins&amp;task=plugin.edit&amp;extension_id=%s\" target=\"_blank\">to łącze, aby otworzyć dodatek</a>, skonfigurować go i zapisać."
 PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_EXTEND_JED_DESC="<strong>Potrzebujesz więcej typów schematów?</strong> Rozszerz o dodatki schematów <a href=\"https://extensions.joomla.org/category/core-enhancements/schema-plugins\" target=\"_blank\" rel=\"noopener noreferrer\">z katalogu rozszerzeń Joomla!</a>."
 PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_LABEL="Schemat"
 PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_TYPE_LABEL="Typ schematu"


### PR DESCRIPTION
Pull Request do problemu #702 .

### Streszczenie zmian
- Zmiana tłumaczenia frazy:
```
PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION="Structured data is a standardised format for organising and representing information on the web. It provides a way to describe the content and meaning of data in a structured manner, making it easier for search engines and other applications to understand and process the information. <a href=\"https://schema.org\" target=\"_blank\" rel=\"noopener noreferrer\">More information on schema.org</a>."
```
- Dodanie informacji o porzuceniu w 6.0
- Duplikacje 2 fraz (wygląda jak by fraza została tylko zmieniany był klucz)

### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
(np. zrób zrzut ekranu, podaj ścieżkę względną do ekranu

### Jak przetestować