### PR TITLE
Fixes 704

### DIFF
--- a/language/pl-PL/joomla.ini
+++ b/language/pl-PL/joomla.ini
@@ -154,7 +154,9 @@ JERROR_LAYOUT_AN_OUT_OF_DATE_BOOKMARK_FAVOURITE="Użyta zakładka jest nieaktual
 JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST="Wystąpił błąd podczas wykonywania powierzonego zadania."
 JERROR_LAYOUT_GO_TO_THE_HOME_PAGE="Przejdź na stronę startową"
 JERROR_LAYOUT_HOME_PAGE="Strona startowa"
+; deprecated will be removed in 6.0
 JERROR_LAYOUT_MIS_TYPED_ADDRESS="Adres został wpisany z błędem"
+JERROR_LAYOUT_MISTYPED_ADDRESS="Adres został wpisany z błędem"
 JERROR_LAYOUT_NOT_ABLE_TO_VISIT="<strong>Możliwe, że nie możesz zobaczyć tej strony, ponieważ</strong>"
 JERROR_LAYOUT_PAGE_NOT_FOUND="Nie znaleziono żądanej strony."
 JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR="Jeśli problem się powtarza, skontaktuj się z administratorem witryny."


### PR DESCRIPTION
Pull Request do problemu #704 .

### Streszczenie zmian
Zmiana nazwy klucza i dodanie informacji o porzuceniu w 6.0
```
; deprecated will be removed in 6.0
JERROR_LAYOUT_MIS_TYPED_ADDRESS="a <strong>mistyped address</strong>"
JERROR_LAYOUT_MISTYPED_ADDRESS="a <strong>mistyped address</strong>"
```

### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
(np. zrób zrzut ekranu, podaj ścieżkę względną do ekranu

### Jak przetestować