### PR TITLE
Fixes 705

### DIFF
--- a/administrator/language/pl-PL/com_finder.ini
+++ b/administrator/language/pl-PL/com_finder.ini
@@ -18,6 +18,8 @@ COM_FINDER_CONFIG_FILTER_COMMONWORDS_LABEL="Filtruj typowe słowa"
 COM_FINDER_CONFIG_FILTER_NUMERICS_LABEL="Filtruj określenia liczbowe"
 COM_FINDER_CONFIG_GATHER_SEARCH_STATISTICS_LABEL="Zbieraj statystyki wyszukiwania"
 COM_FINDER_CONFIG_HIGHLIGHT_CONTENT_SEARCH_TERMS_DESC="Ze względu na wydajność, w wynikach wyszukiwania nie zostanie wyróżnionych więcej niż 10 różnych haseł."
+COM_FINDER_CONFIG_HIGHLIGHT_CONTENT_SEARCH_TERMS_LABEL="Wyróżniaj wyszukiwane słowa"
+; deprecated will be removed in 6.0
 COM_FINDER_CONFIG_HILIGHT_CONTENT_SEARCH_TERMS_LABEL="Wyróżniaj wyszukiwane słowa"
 COM_FINDER_CONFIG_IMAGE_CLASS_LABEL="Klasa obrazu"
 COM_FINDER_CONFIG_LANGUAGE_DEFAULT_DEFAULT_LANGUAGE="Domyślny język witryny"


### PR DESCRIPTION
Pull Request do problemu #705 .

### Streszczenie zmian
Poprawa klucza oraz dodanie informacji o porzuceniu w 6.0
```
COM_FINDER_CONFIG_HIGHLIGHT_CONTENT_SEARCH_TERMS_LABEL="Highlight Search Terms"
; deprecated will be removed in 6.0
COM_FINDER_CONFIG_HILIGHT_CONTENT_SEARCH_TERMS_LABEL="Highlight Search Terms"
```

### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
(np. zrób zrzut ekranu, podaj ścieżkę względną do ekranu

### Jak przetestować