### PR TITLE
Fixes 710

### DIFF
--- a/administrator/language/pl-PL/plg_editors_codemirror.ini
+++ b/administrator/language/pl-PL/plg_editors_codemirror.ini
@@ -6,9 +6,9 @@
 PLG_CODEMIRROR_FIELD_AUTOCLOSEBRACKET_LABEL="Uzupełnianie nawiasów"
 PLG_CODEMIRROR_FIELD_CODEFOLDING_LABEL="Złożony kod"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_LABEL="Niestandardowe rozszerzenia"
-PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESC="Nazwa metody, dostarczona przez moduł do inicjalizacji rozszerzenia. Lub kilka, oddzielone przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
+PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESC="Nazwa metody dostarczona przez moduł do inicjalizacji rozszerzenia, lub kilka oddzielonych przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
 ; deprecated will be removed in 6.0
-PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESCR="Nazwa metody, dostarczona przez moduł do inicjalizacji rozszerzenia. Lub kilka, oddzielone przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
+PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESCR="Nazwa metody dostarczona przez moduł do inicjalizacji rozszerzenia, lub kilka oddzielonych przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_LABEL="Metody inicjalizacji"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESC="Ścieżka względna do pliku modułu, np. media/my-assets/js/my-codemirror-module.js. Lub nazwa modułu, np. @codemirror/language."
 ; deprecated will be removed in 6.0

--- a/administrator/language/pl-PL/plg_editors_codemirror.ini
+++ b/administrator/language/pl-PL/plg_editors_codemirror.ini
@@ -6,8 +6,12 @@
 PLG_CODEMIRROR_FIELD_AUTOCLOSEBRACKET_LABEL="Uzupełnianie nawiasów"
 PLG_CODEMIRROR_FIELD_CODEFOLDING_LABEL="Złożony kod"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_LABEL="Niestandardowe rozszerzenia"
+PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESC="Nazwa metody, dostarczona przez moduł do inicjalizacji rozszerzenia. Lub kilka, oddzielone przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
+; deprecated will be removed in 6.0
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESCR="Nazwa metody, dostarczona przez moduł do inicjalizacji rozszerzenia. Lub kilka, oddzielone przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_LABEL="Metody inicjalizacji"
+PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESC="Ścieżka względna do pliku modułu, np. media/my-assets/js/my-codemirror-module.js. Lub nazwa modułu, np. @codemirror/language."
+; deprecated will be removed in 6.0
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESCR="Ścieżka względna do pliku modułu, np. media/my-assets/js/my-codemirror-module.js. Lub nazwa modułu, np. @codemirror/language."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_LABEL="Nazwa pliku lub modułu"
 PLG_CODEMIRROR_FIELD_FULLSCREEN_LABEL="Pełny ekran"

--- a/administrator/language/pl-PL/plg_editors_codemirror.ini
+++ b/administrator/language/pl-PL/plg_editors_codemirror.ini
@@ -6,9 +6,9 @@
 PLG_CODEMIRROR_FIELD_AUTOCLOSEBRACKET_LABEL="Uzupełnianie nawiasów"
 PLG_CODEMIRROR_FIELD_CODEFOLDING_LABEL="Złożony kod"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_LABEL="Niestandardowe rozszerzenia"
-PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESC="Nazwa metody dostarczona przez moduł do inicjalizacji rozszerzenia, lub kilka oddzielonych przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
+PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESC="Nazwa metody dostarczona przez moduł do inicjalizacji rozszerzenia lub kilka oddzielonych przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
 ; deprecated will be removed in 6.0
-PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESCR="Nazwa metody dostarczona przez moduł do inicjalizacji rozszerzenia, lub kilka oddzielonych przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
+PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESCR="Nazwa metody dostarczona przez moduł do inicjalizacji rozszerzenia lub kilka oddzielonych przecinkami. Przykładowo: bracketMatching (z modułu @codemirror/language)."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_LABEL="Metody inicjalizacji"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESC="Ścieżka względna do pliku modułu, np. media/my-assets/js/my-codemirror-module.js. Lub nazwa modułu, np. @codemirror/language."
 ; deprecated will be removed in 6.0


### PR DESCRIPTION
Pull Request do problemu #710 .

### Streszczenie zmian
Zmiana 2 kluczy oraz dodanie informacji o porzuceniu w 6.0
```
PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESC="Method name, provided by module for extension initialisation. Or multiple, separated by comma. Eg: bracketMatching (from module @codemirror/language)."
; deprecated will be removed in 6.0
PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESCR="Method name, provided by module for extension initialisation. Or multiple, separated by comma. Eg: bracketMatching (from module @codemirror/language)."
PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_LABEL="Initialisation Method(s)"
PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESC="Relative path to the module file, eg: media/my-assets/js/my-codemirror-module.js. Or module name, eg: @codemirror/language."
; deprecated will be removed in 6.0
PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESCR="Relative path to the module file, eg: media/my-assets/js/my-codemirror-module.js. Or module name, eg: @codemirror/language."
```

### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
(np. zrób zrzut ekranu, podaj ścieżkę względną do ekranu

### Jak przetestować