### PR TITLE
Fixes #694

### DIFF
--- a/administrator/language/pl-PL/plg_quickicon_autoupdate.ini
+++ b/administrator/language/pl-PL/plg_quickicon_autoupdate.ini
@@ -1,0 +1,15 @@
+; Joomla! Project
+; (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_QUICKICON_AUTOUPDATE="Skrót - Powiadomienie o statusie automatycznej aktualizacji Joomla!"
+PLG_QUICKICON_AUTOUPDATE_CHECKING="Sprawdzam automatyczne aktualizacje &hellip;"
+PLG_QUICKICON_AUTOUPDATE_DISABLED="Automatyczne aktualizacje są wyłączone."
+PLG_QUICKICON_AUTOUPDATE_ERROR="Nieznany status automatycznej aktualizacji &hellip;"
+PLG_QUICKICON_AUTOUPDATE_GROUP_DESC="Grupa tego dodatku (ta wartość jest porównywana z wartością opcji Grupa w module <strong>Ikony skrótu</strong> celem dodawania ikon)"
+PLG_QUICKICON_AUTOUPDATE_GROUP_LABEL="Grupa"
+PLG_QUICKICON_AUTOUPDATE_OK="Automatyczne aktualizacje są włączone."
+PLG_QUICKICON_AUTOUPDATE_OUTDATED="Połączenie automatycznych aktualizacji jest przerwane."
+PLG_QUICKICON_AUTOUPDATE_UNAVAILABLE="Automatyczne aktualizacje są niedostepne."
+PLG_QUICKICON_AUTOUPDATE_XML_DESCRIPTION="Monitoruje status automatycznej aktualizacji i powiadamia gdy odwiedzisz pulpit panelu administracyjnego."

--- a/administrator/language/pl-PL/plg_quickicon_autoupdate.sys.ini
+++ b/administrator/language/pl-PL/plg_quickicon_autoupdate.sys.ini
@@ -1,0 +1,5 @@
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_QUICKICON_AUTOUPDATE="Skrót - Powiadomienie o statusie automatycznej aktualizacji Joomla!"
+PLG_QUICKICON_AUTOUPDATE_XML_DESCRIPTION="Monitoruje status automatycznej aktualizacji i powiadamia gdy odwiedzisz pulpit panelu administracyjnego."


### PR DESCRIPTION
Pull Request do problemu #694 .

### Streszczenie zmian
Dodanie nowych plików i fraz:
```
PLG_QUICKICON_AUTOUPDATE="Skrót - Powiadomienie o statusie automatycznej aktualizacji Joomla!"
PLG_QUICKICON_AUTOUPDATE_CHECKING="Sprawdzam automatyczne aktualizacje &hellip;"
PLG_QUICKICON_AUTOUPDATE_DISABLED="Automatyczne aktualizacje są wyłączone."
PLG_QUICKICON_AUTOUPDATE_ERROR="Nieznany status automatycznej aktualizacji &hellip;"
PLG_QUICKICON_AUTOUPDATE_GROUP_DESC="Grupa tego dodatku (ta wartość jest porównywana z wartością opcji Grupa w module <strong>Ikony skrótu</strong> celem dodawania ikon)"
PLG_QUICKICON_AUTOUPDATE_GROUP_LABEL="Grupa"
PLG_QUICKICON_AUTOUPDATE_OK="Automatyczne aktualizacje są włączone."
PLG_QUICKICON_AUTOUPDATE_OUTDATED="Połączenie automatycznych aktualizacji jest przerwane."
PLG_QUICKICON_AUTOUPDATE_UNAVAILABLE="Automatyczne aktualizacje są niedostepne."
PLG_QUICKICON_AUTOUPDATE_XML_DESCRIPTION="Monitoruje status automatycznej aktualizacji i powiadamia gdy odwiedzisz pulpit panelu administracyjnego."
```
```
PLG_QUICKICON_AUTOUPDATE="Skrót - Powiadomienie o statusie automatycznej aktualizacji Joomla!"
PLG_QUICKICON_AUTOUPDATE_XML_DESCRIPTION="Monitoruje status automatycznej aktualizacji i powiadamia gdy odwiedzisz pulpit panelu administracyjnego."
```

### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
(np. zrób zrzut ekranu, podaj ścieżkę względną do ekranu

### Jak przetestować