### PR TITLE
Fixes #735

### DIFF
--- a/administrator/language/pl-PL/plg_fields_note.ini
+++ b/administrator/language/pl-PL/plg_fields_note.ini
@@ -1,0 +1,16 @@
+; Joomla! Project
+; (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_FIELDS_NOTE="Pole dodatkowe - Notatka"
+PLG_FIELDS_NOTE_LABEL="Notatka (%s)"
+PLG_FIELDS_NOTE_PARAMS_CLASS_DESC="Klasa, która zostanie użyna na div-ie notatki."
+PLG_FIELDS_NOTE_PARAMS_CLASS_LABEL="Klasa notatki"
+PLG_FIELDS_NOTE_PARAMS_CLOSE_DESC="Pole te decyduje czy wyświetlać \"x\" do zamknięcia notatki. Przyjmuje wartość `true` (dla komunikatów) lub wartość dla atrybutu `data-dismiss` ikony zamknięcia z Bootstrap-a."
+PLG_FIELDS_NOTE_PARAMS_CLOSE_LABEL="Pokaż przyciska Zamknij"
+PLG_FIELDS_NOTE_PARAMS_DESCRIPTION_LABEL="Treść notatki"
+PLG_FIELDS_NOTE_PARAMS_DISPLAY_FRONTEND_LABEL="Pokaż w witrynie"
+PLG_FIELDS_NOTE_PARAMS_HEADING_LABEL="Tag nagłówka"
+PLG_FIELDS_NOTE_PARAMS_LABEL_LABEL="Nagłówek notatki"
+PLG_FIELDS_NOTE_XML_DESCRIPTION="Ten dodatek pozwala na utworzenie nowych pól typu `note` w dowolnym rozszerzeniu obsługującym pola dodatkowe."

--- a/administrator/language/pl-PL/plg_fields_note.sys.ini
+++ b/administrator/language/pl-PL/plg_fields_note.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_FIELDS_NOTE="Pole dodatkowe - Notatka"
+PLG_FIELDS_NOTE_XML_DESCRIPTION="Ten dodatek pozwala na utworzenie nowych pól typu `note` w dowolnym rozszerzeniu obsługującym pola dodatkowe."


### PR DESCRIPTION
Pull Request do problemu #735 .

### Streszczenie zmian
Nowe pliki tłumaczeń dla pola dodatkowego typu Notatka
```
; Joomla! Project
; (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
; License GNU General Public License version 2 or later; see LICENSE.txt
; Note : All ini files need to be saved as UTF-8

PLG_FIELDS_NOTE="Fields - Note"
PLG_FIELDS_NOTE_LABEL="Note (%s)"
PLG_FIELDS_NOTE_PARAMS_CLASS_DESC="The class used on the div of the note."
PLG_FIELDS_NOTE_PARAMS_CLASS_LABEL="Note Class"
PLG_FIELDS_NOTE_PARAMS_CLOSE_DESC="This field controls the display of an \"x\" to close the note. It takes a value of 'true' (for alerts) or the value for the data-dismiss of the Bootstrap close icon."
PLG_FIELDS_NOTE_PARAMS_CLOSE_LABEL="Show Close Button"
PLG_FIELDS_NOTE_PARAMS_DESCRIPTION_LABEL="Note Content"
PLG_FIELDS_NOTE_PARAMS_DISPLAY_FRONTEND_LABEL="Display In Frontend"
PLG_FIELDS_NOTE_PARAMS_HEADING_LABEL="Heading Tag"
PLG_FIELDS_NOTE_PARAMS_LABEL_LABEL="Note Heading"
PLG_FIELDS_NOTE_XML_DESCRIPTION="This plugin lets you create new fields of type 'note' in any extensions where custom fields are supported."
```
```
; Joomla! Project
; (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
; License GNU General Public License version 2 or later; see LICENSE.txt
; Note : All ini files need to be saved as UTF-8

PLG_FIELDS_NOTE="Fields - Note"
PLG_FIELDS_NOTE_XML_DESCRIPTION="This plugin lets you create new fields of type 'note' in any extensions where custom fields are supported."
```
### Gdzie jest wyświetlany ciąg znaków (witryna/zaplecze)?
(np. zrób zrzut ekranu, podaj ścieżkę względną do ekranu

### Jak przetestować