### PR TITLE
Poprawa testowania dla gałęzi innych niż główna (dla 6.0)

### DIFF
--- a/tests/translation/Command/Verify.php
+++ b/tests/translation/Command/Verify.php
@@ -444,12 +444,13 @@ final class Verify
      */
     private function getReleaseTag(string $version): string
     {
+
         $tags = $this->getReleaseTags();
 
         usort($tags, 'version_compare');
 
         $tags = array_filter($tags, static function($tag) use ($version) {
-            return str_starts_with($tag, $version) && !str_contains($tag, '-');
+            return str_starts_with($tag, $version);
         });
 
         return end($tags);


### PR DESCRIPTION
Jak w tytule. Teraz PR do 6.0-dev i 5.4-dev powinno wykrywać właściwie najnowsze wydanie.