### PR TITLE
Ustawienie wymaganej wersji Joomla! w dockerze dla 6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-name: polish-translation-test
+name: joomla_translation_test_j6
 services:
 
   joomla:
-    image: joomla:5-php8.3-apache
+    image: joomla:6.0
     restart: unless-stopped
     ports:
       - "80:80"
@@ -14,7 +14,7 @@ services:
       JOOMLA_DB_PASSWORD: joomla_db
       JOOMLA_DB_NAME: joomla_db
       JOOMLA_SITE_NAME: Test
-      JOOMLA_ADMIN_EMAIL: webmaster@localhost.pl
+      JOOMLA_ADMIN_EMAIL: webmaster@localhost.com
       JOOMLA_ADMIN_USERNAME: test
       JOOMLA_ADMIN_USER: test
       JOOMLA_ADMIN_PASSWORD: testtesttesttest


### PR DESCRIPTION
### Streszczenie zmian
Zmiana wersji Joomla! wymaganej w Dockerze na 6.0 dla tej gałęzi oraz ustawienie uniwersalnej nazwy projektu